### PR TITLE
Fix absolute sddm icon path to work with nixos

### DIFF
--- a/sddm/5.0/Layan-light/Main.qml
+++ b/sddm/5.0/Layan-light/Main.qml
@@ -202,28 +202,28 @@ PlasmaCore.ColorScope {
 
                 actionItems: [
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Layan-light/assets/suspend_primary.svgz"
+                        iconSource: Qt.resolvedUrl("assets/suspend_primary.svgz")
                         text: i18ndc("plasma_lookandfeel_org.kde.lookandfeel","Suspend to RAM","Sleep")
                         onClicked: sddm.suspend()
                         enabled: sddm.canSuspend
                         visible: !inputPanel.keyboardActive
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Layan-light/assets/restart_primary.svgz"
+                        iconSource: Qt.resolvedUrl("assets/restart_primary.svgz")
                         text: i18nd("plasma_lookandfeel_org.kde.lookandfeel","Restart")
                         onClicked: sddm.reboot()
                         enabled: sddm.canReboot
                         visible: !inputPanel.keyboardActive
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Layan-light/assets/shutdown_primary.svgz"
+                        iconSource: Qt.resolvedUrl("assets/shutdown_primary.svgz")
                         text: i18nd("plasma_lookandfeel_org.kde.lookandfeel","Shut Down")
                         onClicked: sddm.powerOff()
                         enabled: sddm.canPowerOff
                         visible: !inputPanel.keyboardActive
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Layan-light/assets/switch_primary.svgz"
+                        iconSource: Qt.resolvedUrl("assets/switch_primary.svgz")
                         text: i18ndc("plasma_lookandfeel_org.kde.lookandfeel", "For switching to a username and password prompt", "Other...")
                         onClicked: mainStack.push(userPromptComponent)
                         enabled: true

--- a/sddm/5.0/Layan/Main.qml
+++ b/sddm/5.0/Layan/Main.qml
@@ -202,28 +202,28 @@ PlasmaCore.ColorScope {
 
                 actionItems: [
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Layan/assets/suspend_primary.svgz"
+                        iconSource: Qt.resolvedUrl("assets/suspend_primary.svgz")
                         text: i18ndc("plasma_lookandfeel_org.kde.lookandfeel","Suspend to RAM","Sleep")
                         onClicked: sddm.suspend()
                         enabled: sddm.canSuspend
                         visible: !inputPanel.keyboardActive
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Layan/assets/restart_primary.svgz"
+                        iconSource: Qt.resolvedUrl("assets/restart_primary.svgz")
                         text: i18nd("plasma_lookandfeel_org.kde.lookandfeel","Restart")
                         onClicked: sddm.reboot()
                         enabled: sddm.canReboot
                         visible: !inputPanel.keyboardActive
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Layan/assets/shutdown_primary.svgz"
+                        iconSource: Qt.resolvedUrl("assets/shutdown_primary.svgz")
                         text: i18nd("plasma_lookandfeel_org.kde.lookandfeel","Shut Down")
                         onClicked: sddm.powerOff()
                         enabled: sddm.canPowerOff
                         visible: !inputPanel.keyboardActive
                     },
                     ActionButton {
-                        iconSource: "/usr/share/sddm/themes/Layan/assets/switch_primary.svgz"
+                        iconSource: Qt.resolvedUrl("assets/switch_primary.svgz")
                         text: i18ndc("plasma_lookandfeel_org.kde.lookandfeel", "For switching to a username and password prompt", "Other...")
                         onClicked: mainStack.push(userPromptComponent)
                         enabled: true

--- a/sddm/6.0/Layan-light/Main.qml
+++ b/sddm/6.0/Layan-light/Main.qml
@@ -209,28 +209,28 @@ Item {
                 actionItemsVisible: !inputPanel.keyboardActive
                 actionItems: [
                     ActionButton {
-                        icon.name: "/usr/share/sddm/themes/Layan-light/assets/suspend_primary.svgz"
+                        icon.name: Qt.resolvedUrl("assets/suspend_primary.svgz")
                         text: i18ndc("plasma_lookandfeel_org.kde.lookandfeel", "Suspend to RAM", "Sleep")
                         font.pointSize: parseInt(config.fontSize) + 1
                         onClicked: sddm.suspend()
                         enabled: sddm.canSuspend
                     },
                     ActionButton {
-                        icon.name: "/usr/share/sddm/themes/Layan-light/assets/restart_primary.svgz"
+                        icon.name: Qt.resolvedUrl("assets/restart_primary.svgz")
                         text: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Restart")
                         font.pointSize: parseInt(config.fontSize) + 1
                         onClicked: sddm.reboot()
                         enabled: sddm.canReboot
                     },
                     ActionButton {
-                        icon.name: "/usr/share/sddm/themes/Layan-light/assets/shutdown_primary.svgz"
+                        icon.name: Qt.resolvedUrl("assets/shutdown_primary.svgz")
                         text: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Shut Down")
                         font.pointSize: parseInt(config.fontSize) + 1
                         onClicked: sddm.powerOff()
                         enabled: sddm.canPowerOff
                     },
                     ActionButton {
-                        icon.name: "/usr/share/sddm/themes/Layan-light/assets/switch_primary.svgz"
+                        icon.name: Qt.resolvedUrl("assets/switch_primary.svgz")
                         text: i18ndc("plasma_lookandfeel_org.kde.lookandfeel", "For switching to a username and password prompt", "Other…")
                         font.pointSize: parseInt(config.fontSize) + 1
                         onClicked: mainStack.push(userPromptComponent)

--- a/sddm/6.0/Layan/Main.qml
+++ b/sddm/6.0/Layan/Main.qml
@@ -209,28 +209,28 @@ Item {
                 actionItemsVisible: !inputPanel.keyboardActive
                 actionItems: [
                     ActionButton {
-                        icon.name: "/usr/share/sddm/themes/Layan/assets/suspend_primary.svgz"
+                        icon.name: Qt.resolvedUrl("assets/suspend_primary.svgz")
                         text: i18ndc("plasma_lookandfeel_org.kde.lookandfeel", "Suspend to RAM", "Sleep")
                         font.pointSize: parseInt(config.fontSize) + 1
                         onClicked: sddm.suspend()
                         enabled: sddm.canSuspend
                     },
                     ActionButton {
-                        icon.name: "/usr/share/sddm/themes/Layan/assets/restart_primary.svgz"
+                        icon.name: Qt.resolvedUrl("assets/restart_primary.svgz")
                         text: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Restart")
                         font.pointSize: parseInt(config.fontSize) + 1
                         onClicked: sddm.reboot()
                         enabled: sddm.canReboot
                     },
                     ActionButton {
-                        icon.name: "/usr/share/sddm/themes/Layan/assets/shutdown_primary.svgz"
+                        icon.name: Qt.resolvedUrl("assets/shutdown_primary.svgz")
                         text: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Shut Down")
                         font.pointSize: parseInt(config.fontSize) + 1
                         onClicked: sddm.powerOff()
                         enabled: sddm.canPowerOff
                     },
                     ActionButton {
-                        icon.name: "/usr/share/sddm/themes/Layan/assets/switch_primary.svgz"
+                        icon.name: Qt.resolvedUrl("assets/switch_primary.svgz")
                         text: i18ndc("plasma_lookandfeel_org.kde.lookandfeel", "For switching to a username and password prompt", "Other…")
                         font.pointSize: parseInt(config.fontSize) + 1
                         onClicked: mainStack.push(userPromptComponent)


### PR DESCRIPTION
In SDDM Main.qml, the icon path are specified in absolute which broke the icon display on system like nixos (which do not have a /usr/share/ path)